### PR TITLE
P2/630p2 avoid blocking fs.read file sync post creation

### DIFF
--- a/docs/reviews/P2-PR4-self-review.md
+++ b/docs/reviews/P2-PR4-self-review.md
@@ -1,0 +1,19 @@
+# P2 PR 4 Self Review
+# Does this change affect any behaviors?
+- No, intended behavior was changed but the post creation still works and also being able to upload photos.
+
+---
+# Does this affect app rendering?
+- No, this change is in the backend controller and does not affect the rendering.
+
+---
+# Does this PR stay within scope?
+- Yes, all changes are within the scope.
+- This is replacing blocking file I/O during post creation.
+---
+# Decision
+- Approved
+
+--- 
+# Approval Reason
+-  This PR is safe to merge becaues it improves backend performance without changing user behavior. Posting and uploading a photo still works.

--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -13,8 +13,9 @@ const create = (req, res, next) => {
     let post = new Post(fields)
     post.postedBy= req.profile
     if(files.photo){
-      post.photo.data = fs.readFileSync(files.photo.path)
-      post.photo.contentType = files.photo.type
+	    post.photo.data = await fs.promises.readFile(files.photo.path)
+	    // post.photo.data = fs.readFileSync(files.photo.path)
+      	    post.photo.contentType = files.photo.type
     }
     try {
       let result = await post.save()

--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -14,7 +14,6 @@ const create = (req, res, next) => {
     post.postedBy= req.profile
     if(files.photo){
 	    post.photo.data = await fs.promises.readFile(files.photo.path)
-	    // post.photo.data = fs.readFileSync(files.photo.path)
       	    post.photo.contentType = files.photo.type
     }
     try {


### PR DESCRIPTION
Closes #18
**Summary of changes:**
- Replaced blocking `fs.readFileSync`.
- Updated the `post.controller.js`  to use asynchronous file reading.
- Kept the logic and error handling the same.

**Verification:**
- Ran `npm run development`
- Confirmed that server compiles and application starts.
- Confirmed that posting photos still works.
- Confirmed that the applications still functioned correctly.

**Evidence:**
- SonarQube identified this smell: *"Prefer `node:fs` over `fs`."*
- Before: 
` if(files.photo){
      post.photo.data = fs.readFileSync(files.photo.path)
      post.photo.contentType = files.photo.type
    }`
- After: 
`if(files.photo){
            post.photo.data = await fs.promises.readFile(files.photo.path)
            post.photo.contentType = files.photo.type
    }`

**Self Review:**
- The self review was added to `docs/reviews` 