### PR TITLE
Completed 630:P2 [SonarQube] dbErrorHandler only shows last error

### DIFF
--- a/docs/reviews/P2-PR6-self-review.md
+++ b/docs/reviews/P2-PR6-self-review.md
@@ -1,0 +1,20 @@
+# P2 PR 6 Self Review
+# Does this change affect any behaviors?
+- No, this change does not affect any functional behavior. The API still returns error like before but all validation and duplicate keys errors are shown.
+
+---
+# Does this affect app rendering?
+- No, this change was in the backend error handling and no frontend chages were made.
+
+---
+# Does this PR stay within scope?
+- Yes, this PR stays within the scope. It refactors the `dbErrorHandler.js` to  ensure error messages are not overwritten.
+
+---
+# Decision
+- Approved
+
+---
+# Approval Reason
+- This PR is safe to merge because it improves backend maintainability without changing user behavior. 
+- Manual verification confirmed that duplicate key errors return correctly and also validation errors. 

--- a/server/helpers/dbErrorHandler.js
+++ b/server/helpers/dbErrorHandler.js
@@ -4,15 +4,13 @@
  * Get unique error field name
  */
 const getUniqueErrorMessage = (err) => {
-    let output
     try {
-        let fieldName = err.message.substring(err.message.lastIndexOf('.$') + 2, err.message.lastIndexOf('_1'))
-        output = fieldName.charAt(0).toUpperCase() + fieldName.slice(1) + ' already exists'
+	    const fieldName = err.message.substring(err.message.lastIndexOf('.$') + 2, err.message.lastIndexOf('_1'))
+	    return fieldName.charAt(0).toUpperCase() + fieldName.slice(1) + ' already exists'
     } catch (ex) {
-        output = 'Unique field already exists'
+	    console.error('Error parsing unique field name:', ex)
+	    return 'Unique field already exists'
     }
-
-    return output
 }
 
 /**
@@ -30,10 +28,8 @@ const getErrorMessage = (err) => {
             default:
                 message = 'Something went wrong'
         }
-    } else {
-        for (let errName in err.errors) {
-            if (err.errors[errName].message) message = err.errors[errName].message
-        }
+    } else if(err.errors) {
+	    message = Object.values(err.errors).map(e => e.message).join('. ')
     }
 
     return message


### PR DESCRIPTION
Closes #20 
**Summary of changes:**
- Refactored `dbErrorHandler.js` to handle exceptions properly in `getUniqueErrorMessage`.

**Verification:**
- Ran `npm run development`
- Confirmed that server compiles and application starts.
- Manual testing to confirm that duplicate key and validation errors are correct.

**Evidence:**
- SonarQube identified this smell: *"Handle this exception or don't catch it at all."*
- Before: 
`try {
        let fieldName = err.message.substring(err.message.lastIndexOf('.$') + 2, err.message.lastIndexOf('_1'))
        output = fieldName.charAt(0).toUpperCase() + fieldName.slice(1) + ' already exists'
    } catch (ex) {
        output = 'Unique field already exists'
    }`
- After: 
`try {
            const fieldName = err.message.substring(err.message.lastIndexOf('.$') + 2, err.message.lastIndexOf('_1'))
            return fieldName.charAt(0).toUpperCase() + fieldName.slice(1) + ' already exists'
    } catch (ex) {
            console.error('Error parsing unique field name:', ex)
            return 'Unique field already exists'
    }`

**Self Review:**
- The self review was added to `docs/reviews` 

