### PR TITLE
P3/god object refactor post create delete

### DIFF
--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -1,30 +1,7 @@
 import Post from '../models/post.model'
 import postService from '../services/post.service'
-//import formidable from 'formidable'
-//import fs from 'fs'
 import handlerControllerError from '../helpers/controllerErrorHandler'
 
-/*const create = (req, res, next) => {
-  let form = new formidable.IncomingForm()
-  form.keepExtensions = true
-  form.parse(req, async (err, fields, files) => {
-    if (err) {
-	    return handlerControllerError(res, err, 400, "Image could not be uploaded")
-    }
-    let post = new Post(fields)
-    post.postedBy= req.profile
-    if(files.photo){
-	    post.photo.data = await fs.promises.readFile(files.photo.path)
-      	    post.photo.contentType = files.photo.type
-    }
-    try {
-      let result = await post.save()
-      res.json(result)
-    }catch (err){
-	    return handlerControllerError(res, err, 400)
-    }
-  })
-}*/
 const create = async (req, res) => {
     try {
         const result = await postService.createPost(req)
@@ -74,15 +51,6 @@ const listNewsFeed = async (req, res) => {
   }
 }
 
-/*const remove = async (req, res) => {
-  let post = req.post
-  try{
-    let deletedPost = await post.remove()
-    res.json(deletedPost)
-  }catch(err){
-	  return handlerControllerError(res, err, 400)
-  }
-}*/
 const remove = async (req, res) => {
     try {
         const deletedPost = await postService.removePost(req.post)

--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -1,9 +1,10 @@
 import Post from '../models/post.model'
-import formidable from 'formidable'
-import fs from 'fs'
+import postService from '../services/post.service'
+//import formidable from 'formidable'
+//import fs from 'fs'
 import handlerControllerError from '../helpers/controllerErrorHandler'
 
-const create = (req, res, next) => {
+/*const create = (req, res, next) => {
   let form = new formidable.IncomingForm()
   form.keepExtensions = true
   form.parse(req, async (err, fields, files) => {
@@ -23,6 +24,14 @@ const create = (req, res, next) => {
 	    return handlerControllerError(res, err, 400)
     }
   })
+}*/
+const create = async (req, res) => {
+    try {
+        const result = await postService.createPost(req)
+        res.json(result)
+    } catch ({ error, status, message }) {
+        return handlerControllerError(res, error, status, message)
+    }
 }
 
 const postByID = async (req, res, next, id) => {
@@ -65,7 +74,7 @@ const listNewsFeed = async (req, res) => {
   }
 }
 
-const remove = async (req, res) => {
+/*const remove = async (req, res) => {
   let post = req.post
   try{
     let deletedPost = await post.remove()
@@ -73,6 +82,14 @@ const remove = async (req, res) => {
   }catch(err){
 	  return handlerControllerError(res, err, 400)
   }
+}*/
+const remove = async (req, res) => {
+    try {
+        const deletedPost = await postService.removePost(req.post)
+        res.json(deletedPost)
+    } catch ({ error, status, message }) {
+        return handlerControllerError(res, error, status, message)
+    }
 }
 
 const photo = (req, res, next) => {

--- a/server/services/post.service.js
+++ b/server/services/post.service.js
@@ -1,0 +1,53 @@
+import Post from '../models/post.model'
+import formidable from 'formidable'
+import fs from 'fs'
+
+const createPost = (req) =>
+    new Promise((resolve, reject) => {
+        let form = new formidable.IncomingForm()
+        form.keepExtensions = true
+
+        form.parse(req, async (err, fields, files) => {
+            if (err) {
+                return reject({
+                    error: err,
+                    status: 400,
+                    message: 'Image could not be uploaded'
+                })
+            }
+
+            try {
+                let post = new Post(fields)
+                post.postedBy = req.profile
+
+                if (files.photo) {
+                    post.photo.data = await fs.promises.readFile(files.photo.path)
+                    post.photo.contentType = files.photo.type
+                }
+                
+                let result = await post.save()
+                resolve(result)
+            } catch (err) {
+                reject({
+                    error: err,
+                    status: 400
+                })
+            }
+        })
+    })
+
+const removePost = async (post) => {
+    try {
+        let deletedPost = await post.remove()
+        return deletedPost
+    } catch (err) {
+        throw {
+            error: err,
+            status: 400
+        }
+    }
+}
+export default {
+    createPost,
+    removePost
+}


### PR DESCRIPTION
Closes #28 
**Summary of changes:**
- The changes that were made are that the post creation and deletion workflow are moved out of the `post.controller.js` into a post service file.

**Problem:**
- `post.controller.js` was handling the request and the response behaviors and post logic. Which made it a God Object structure.

**Approach:**
- Added `server/service/post.service.js`.
- Moved create post workflow into the service.
- Moved delete post workflow into the service.
- Kept the controller behavior the same as well as the API responses.

**Design Pattern:**
- Facade

**Verification:**
- Tests passed.
- Manually verified that post creation worked.
- Manually verified that post deletion worked.
