### PR TITLE
P3/shotgun surgery consolidate follow unfollow

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -5,6 +5,7 @@ import formidable from 'formidable'
 import fs from 'fs'
 import profileImage from './../../client/assets/images/profile-pic.png'
 import handlerControllerError from '../helpers/controllerErrorHandler'
+import followService from '../services/follow.service'
 
 const create = async (req, res) => {
   const user = new User(req.body)
@@ -99,7 +100,7 @@ const defaultPhoto = (req, res) => {
   return res.sendFile(process.cwd()+profileImage)
 }
 
-const addFollowing = async (req, res, next) => {
+/*const addFollowing = async (req, res, next) => {
   try{
     await User.findByIdAndUpdate(req.body.userId, {$push: {following: req.body.followId}}) 
     next()
@@ -130,6 +131,7 @@ const removeFollowing = async (req, res, next) => {
 	  return handlerControllerError(res, err, 400)
   }
 }
+
 const removeFollower = async (req, res) => {
   try{
     let result = await User.findByIdAndUpdate(req.body.unfollowId, {$pull: {followers: req.body.userId}}, {new: true})
@@ -142,6 +144,25 @@ const removeFollower = async (req, res) => {
   }catch(err){
 	  return handlerControllerError(res, err, 400)
   }
+}
+*/
+
+const follow = async (req, res) => {
+    try {
+        const result = await followService.follow(req.body.userId, req.body.followId)
+        res.json(result)
+    } catch (err) {
+        return handlerControllerError(res, err, 400)
+    }
+}
+
+const unfollow = async (req, res) => {
+    try {
+        const result = await followService.unfollow(req.body.userId, req.body.unfollowId)
+        res.json(result)
+    } catch (err) {
+        return handlerControllerError(res, err, 400)
+    }
 }
 
 const findPeople = async (req, res) => {
@@ -164,9 +185,11 @@ export default {
   update,
   photo,
   defaultPhoto,
-  addFollowing,
+ /* addFollowing,
   addFollower,
   removeFollowing,
-  removeFollower,
+  removeFollower,*/
+  follow,
+  unfollow,
   findPeople
 }

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -13,10 +13,17 @@ router.route('/api/users/photo/:userId')
 router.route('/api/users/defaultphoto')
   .get(userCtrl.defaultPhoto)
 
+/*
 router.route('/api/users/follow')
     .put(authCtrl.requireSignin, userCtrl.addFollowing, userCtrl.addFollower)
 router.route('/api/users/unfollow')
     .put(authCtrl.requireSignin, userCtrl.removeFollowing, userCtrl.removeFollower)
+*/
+
+router.route('/api/users/follow')
+    .put(authCtrl.requireSignin, userCtrl.follow)
+router.route('/api/users/unfollow')
+    .put(authCtrl.requireSignin, userCtrl.unfollow)
 
 router.route('/api/users/findpeople/:userId')
    .get(authCtrl.requireSignin, userCtrl.findPeople)

--- a/server/services/follow.service.js
+++ b/server/services/follow.service.js
@@ -1,0 +1,44 @@
+import User from '../models/user.model'
+
+const sanitizeUser = (user) => {
+    user.hashed_password = undefined
+    user.salt = undefined
+    return user
+}
+
+const follow = async (userId, followId) => {
+    await User.findByIdAndUpdate(userId, { $push: { following: followId } })
+    
+    let result = await User.findByIdAndUpdate(
+        followId,
+        { $push: { followers: userId } },
+        { new: true }
+        )
+        
+        .populate('following', '_id name')
+        .populate('followers', '_id name')
+        .exec()
+
+        return sanitizeUser(result)
+}
+
+const unfollow = async (userId, unfollowId) => {
+    await User.findByIdAndUpdate(userId, { $push: { following: unfollowId } })
+
+    let result = await User.findByIdAndUpdate(
+        unfollowId,
+        { $push: { followers: userId } },
+        { new: true }
+        )
+
+        .populate('following', '_id name')
+        .populate('followers', '_id name')
+        .exec()
+
+        return sanitizeUser(result)
+}
+
+export default {
+    follow,
+    unfollow
+}


### PR DESCRIPTION
Closes #31  
**Summary of changes:**
- The changes that were made are that the follow and unfollow workflow are moved out of the `server/controllers/user.controller.js` and `server/routes/user.routes.js` into a mediator service file.

**Problem:**
- The problem is that if the follow and unfollow operations chain multiple functions in the route layer and that makes it a shotgun surgery where if a change is made it has to modify multiple files.

**Approach:**
- Added `server/service/follow.service.js`.
- Put all operation steps in one service method.
- Updated the controller to have follow and unfollow methods.
- Simplified routes to call single controller method.

**Design Pattern:**
- Mediator

**Verification:**
- Tests passed.
- Manually verified that follow worked.
- Manually verified that unfollow worked.
