### PR TITLE
P3/reinventing the wheel multipart upload template

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -1,11 +1,12 @@
 import User from '../models/user.model'
 import extend from 'lodash/extend'
 import errorHandler from './../helpers/dbErrorHandler'
-import formidable from 'formidable'
+//import formidable from 'formidable'
 import fs from 'fs'
 import profileImage from './../../client/assets/images/profile-pic.png'
 import handlerControllerError from '../helpers/controllerErrorHandler'
 import followService from '../services/follow.service'
+import uploadService from '../services/upload.service'
 
 const create = async (req, res) => {
   const user = new User(req.body)
@@ -51,6 +52,7 @@ const list = async (req, res) => {
   }
 }
 
+/*
 const update = (req, res) => {
   let form = new formidable.IncomingForm()
   form.keepExtensions = true
@@ -74,6 +76,30 @@ const update = (req, res) => {
 	    return handlerControllerError(res, err, 400)
     }
   })
+}
+*/
+
+const update = async (req, res) => {
+    try {
+        const { fields, files } = await uploadService.parseMultipartForm(
+        req,
+        'Photo could not be uploaded'
+        )
+        let user = req.profile
+        user = extend(user, fields)
+        user.updated = Date.now()
+
+        if (files.photo) {
+            user.photo.data = fs.readFileSync(files.photo.path)
+            user.photo.contentType = files.photo.type
+        }
+        await user.save()
+        user.hashed_password = undefined
+        user.salt = undefined
+        res.json(user)
+    } catch (err) {
+        return handlerControllerError(res, err.error || err, err.status || 400, err.message)
+    }
 }
 
 const remove = async (req, res) => {

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -1,7 +1,6 @@
 import User from '../models/user.model'
 import extend from 'lodash/extend'
 import errorHandler from './../helpers/dbErrorHandler'
-//import formidable from 'formidable'
 import fs from 'fs'
 import profileImage from './../../client/assets/images/profile-pic.png'
 import handlerControllerError from '../helpers/controllerErrorHandler'
@@ -52,33 +51,6 @@ const list = async (req, res) => {
   }
 }
 
-/*
-const update = (req, res) => {
-  let form = new formidable.IncomingForm()
-  form.keepExtensions = true
-  form.parse(req, async (err, fields, files) => {
-    if (err) {
-	    return handlerControllerError(res, err, 400, "Photo could not be uploaded")
-    }
-    let user = req.profile
-    user = extend(user, fields)
-    user.updated = Date.now()
-    if(files.photo){
-      user.photo.data = fs.readFileSync(files.photo.path)
-      user.photo.contentType = files.photo.type
-    }
-    try {
-      await user.save()
-      user.hashed_password = undefined
-      user.salt = undefined
-      res.json(user)
-    } catch (err) {
-	    return handlerControllerError(res, err, 400)
-    }
-  })
-}
-*/
-
 const update = async (req, res) => {
     try {
         const { fields, files } = await uploadService.parseMultipartForm(
@@ -126,53 +98,6 @@ const defaultPhoto = (req, res) => {
   return res.sendFile(process.cwd()+profileImage)
 }
 
-/*const addFollowing = async (req, res, next) => {
-  try{
-    await User.findByIdAndUpdate(req.body.userId, {$push: {following: req.body.followId}}) 
-    next()
-  }catch(err){
-	  return handlerControllerError(res, err, 400)
-  }
-}
-
-const addFollower = async (req, res) => {
-  try{
-    let result = await User.findByIdAndUpdate(req.body.followId, {$push: {followers: req.body.userId}}, {new: true})
-                            .populate('following', '_id name')
-                            .populate('followers', '_id name')
-                            .exec()
-      result.hashed_password = undefined
-      result.salt = undefined
-      res.json(result)
-    }catch(err) {
-	    return handlerControllerError(res, err, 400)
-    }
-}
-
-const removeFollowing = async (req, res, next) => {
-  try{
-    await User.findByIdAndUpdate(req.body.userId, {$pull: {following: req.body.unfollowId}}) 
-    next()
-  }catch(err) {
-	  return handlerControllerError(res, err, 400)
-  }
-}
-
-const removeFollower = async (req, res) => {
-  try{
-    let result = await User.findByIdAndUpdate(req.body.unfollowId, {$pull: {followers: req.body.userId}}, {new: true})
-                            .populate('following', '_id name')
-                            .populate('followers', '_id name')
-                            .exec() 
-    result.hashed_password = undefined
-    result.salt = undefined
-    res.json(result)
-  }catch(err){
-	  return handlerControllerError(res, err, 400)
-  }
-}
-*/
-
 const follow = async (req, res) => {
     try {
         const result = await followService.follow(req.body.userId, req.body.followId)
@@ -211,10 +136,6 @@ export default {
   update,
   photo,
   defaultPhoto,
- /* addFollowing,
-  addFollower,
-  removeFollowing,
-  removeFollower,*/
   follow,
   unfollow,
   findPeople

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -13,13 +13,6 @@ router.route('/api/users/photo/:userId')
 router.route('/api/users/defaultphoto')
   .get(userCtrl.defaultPhoto)
 
-/*
-router.route('/api/users/follow')
-    .put(authCtrl.requireSignin, userCtrl.addFollowing, userCtrl.addFollower)
-router.route('/api/users/unfollow')
-    .put(authCtrl.requireSignin, userCtrl.removeFollowing, userCtrl.removeFollower)
-*/
-
 router.route('/api/users/follow')
     .put(authCtrl.requireSignin, userCtrl.follow)
 router.route('/api/users/unfollow')

--- a/server/services/post.service.js
+++ b/server/services/post.service.js
@@ -1,42 +1,6 @@
 import Post from '../models/post.model'
-//import formidable from 'formidable'
 import uploadService from './upload.service'
 import fs from 'fs'
-
-/*const createPost = (req) =>
-    new Promise((resolve, reject) => {
-        let form = new formidable.IncomingForm()
-        form.keepExtensions = true
-
-        form.parse(req, async (err, fields, files) => {
-            if (err) {
-                return reject({
-                    error: err,
-                    status: 400,
-                    message: 'Image could not be uploaded'
-                })
-            }
-
-            try {
-                let post = new Post(fields)
-                post.postedBy = req.profile
-
-                if (files.photo) {
-                    post.photo.data = await fs.promises.readFile(files.photo.path)
-                    post.photo.contentType = files.photo.type
-                }
-                
-                let result = await post.save()
-                resolve(result)
-            } catch (err) {
-                reject({
-                    error: err,
-                    status: 400
-                })
-            }
-        })
-    })
-*/
 
 const createPost = async (req) => {
     try {

--- a/server/services/post.service.js
+++ b/server/services/post.service.js
@@ -1,8 +1,9 @@
 import Post from '../models/post.model'
-import formidable from 'formidable'
+//import formidable from 'formidable'
+import uploadService from './upload.service'
 import fs from 'fs'
 
-const createPost = (req) =>
+/*const createPost = (req) =>
     new Promise((resolve, reject) => {
         let form = new formidable.IncomingForm()
         form.keepExtensions = true
@@ -35,6 +36,32 @@ const createPost = (req) =>
             }
         })
     })
+*/
+
+const createPost = async (req) => {
+    try {
+        const { fields, file } = await uploadService.parseMultipartForm(
+        req,
+        'Image could not be uploaded'
+    )
+        let post = new Post(fields)
+        post.postedBy = req.profile
+
+        if (files.photo) {
+            post.photo.data = await fs.promises.readFile(files.photo.path)
+            post.photo.contentType = files.photo.type
+        }
+        let result = await post.save()
+        return result
+    } catch (err) {
+        if (err.status) throw err
+
+        throw {
+            error: err,
+            status: 400
+        }
+    }
+}
 
 const removePost = async (post) => {
     try {

--- a/server/services/upload.service.js
+++ b/server/services/upload.service.js
@@ -1,0 +1,19 @@
+import formidable from 'formidable'
+
+const parseMultipartForm = (req, errorMessage) =>
+    new Promise((resolve, reject) => {
+        let form = new formidable.IncomingForm()
+        form.parse(req, (err, fields, files) => {
+            if (err) {
+                return reject({
+                    error: err,
+                    status: 400,
+                    message: errorMessage
+                })
+            }
+            resolve({ fields, files})
+        })
+    })
+export default {
+    parseMultipartForm
+}


### PR DESCRIPTION
Closes #33 
**Summary of changes:**
- The changes that were made are that the upload logic that was in multiple part were refactored into one shared upload service.

**Problem:**
- The problem is that there was duplicated logic across multiple controllers which can make maintenance more risky and inconsistent.

**Approach:**
- Added `server/service/upload.service.js`.
- Moved the post and user logic to shared method.
- Removed duplicated setup for controllers.

**Design Pattern:**
- Template Method

**Verification:**
- Tests passed.
- Manually verified that follow worked.
- Manually verified that unfollow worked.